### PR TITLE
Furniture is updating surrounding furniture regardless of size

### DIFF
--- a/Assets/Scripts/Models/Furniture.cs
+++ b/Assets/Scripts/Models/Furniture.cs
@@ -244,7 +244,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + proto.Height + 1); ypos++)
             {
-                t = World.current.GetTileAt(xpos, ypos + 1);
+                t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);
@@ -612,7 +612,7 @@ public class Furniture : IXmlSerializable, ISelectable
         {
             for (int ypos = y - 1; ypos < (y + fheight + 1); ypos++)
             {
-                Tile t = World.current.GetTileAt(xpos, ypos + 1);
+                Tile t = World.current.GetTileAt(xpos, ypos);
                 if (t != null && t.furniture != null && t.furniture.cbOnChanged != null)
                 {
                     t.furniture.cbOnChanged(t.furniture);


### PR DESCRIPTION
When placing or removing furniture, all surrounding furniture gets
updated. Regardless if they are same type or connects to neighbours.
This is first step in fixing doors connecting correctly to walls.